### PR TITLE
fix(ingest): perfs

### DIFF
--- a/index/src/index.ts
+++ b/index/src/index.ts
@@ -2,44 +2,43 @@ import * as fs from "fs";
 import * as path from "path";
 import * as csv from "fast-csv";
 import {
-  add,
+  esClient,
   createIndex,
   updateAlias,
   deleteOldIndices,
   getDocsCount,
 } from "./elastic";
-import { Enterprise } from "./enterprise";
+import { Enterprise, mapEnterprise } from "./enterprise";
 
 const ASSEMBLY_FILE =
   process.env.ASSEMBLY_FILE || "../assembly/output/assembly.csv";
 
-const insertEntreprises = (indexName: string) => {
+async function * manipulate (stream: any) {
+  for await (const enterprise of stream) {
+    yield mapEnterprise(enterprise)
+  }
+}
+
+
+// apply mapEntreprise to the CSV stream
+// then bulk insert with Es client
+const insertEntreprises = async (indexName: string) => {
+
   const stream = fs.createReadStream(path.resolve(ASSEMBLY_FILE));
+  const csvStream = csv.parseStream(stream, {headers:true});
 
-  const BUFFER_SIZE = 500;
-  let enterprisesBuffer: Enterprise[] = [];
-
-  stream
-    .pipe(csv.parse({ headers: true }))
-    .on("error", (error) => console.error(error))
-    .on("data", async (e) => {
-      enterprisesBuffer.push(e);
-
-      if (enterprisesBuffer.length >= BUFFER_SIZE) {
-        // create an immutable copy of the array
-        const batch = enterprisesBuffer.slice();
-        enterprisesBuffer = [];
-        await add(batch, indexName);
-
-        // to run experiments
-        // stream.destroy();
-      }
-    })
-    .on("end", (rowCount: number) => console.log(`Parsed ${rowCount} rows`));
-
-  return new Promise((fulfill) =>
-    stream.on("finish", fulfill).on("close", fulfill)
-  );
+  return esClient.helpers.bulk({
+    //@ts-expect-error
+    datasource: manipulate(csvStream),
+    onDocument: (enterprise: Enterprise) => {
+      return  {
+          index: {
+            _index: indexName,
+            _id: enterprise.siret,
+          },
+        }
+    },
+  });
 };
 
 if (require.main === module) {

--- a/index/src/index.ts
+++ b/index/src/index.ts
@@ -13,31 +13,27 @@ import { Enterprise, mapEnterprise } from "./enterprise";
 const ASSEMBLY_FILE =
   process.env.ASSEMBLY_FILE || "../assembly/output/assembly.csv";
 
-async function * manipulate (stream: any) {
+async function* manipulate(stream: any) {
   for await (const enterprise of stream) {
-    yield mapEnterprise(enterprise)
+    yield mapEnterprise(enterprise);
   }
 }
-
 
 // apply mapEntreprise to the CSV stream
 // then bulk insert with Es client
 const insertEntreprises = async (indexName: string) => {
-
   const stream = fs.createReadStream(path.resolve(ASSEMBLY_FILE));
-  const csvStream = csv.parseStream(stream, {headers:true});
+  const csvStream = csv.parseStream(stream, { headers: true });
 
   return esClient.helpers.bulk({
     //@ts-expect-error
     datasource: manipulate(csvStream),
-    onDocument: (enterprise: Enterprise) => {
-      return  {
-          index: {
-            _index: indexName,
-            _id: enterprise.siret,
-          },
-        }
-    },
+    onDocument: (enterprise: Enterprise) => ({
+      index: {
+        _index: indexName,
+        _id: enterprise.siret,
+      },
+    }),
   });
 };
 

--- a/index/src/index.ts
+++ b/index/src/index.ts
@@ -28,6 +28,7 @@ const insertEntreprises = async (indexName: string) => {
   return esClient.helpers.bulk({
     //@ts-expect-error
     datasource: manipulate(csvStream),
+    refreshOnCompletion: true,
     onDocument: (enterprise: Enterprise) => ({
       index: {
         _index: indexName,
@@ -39,9 +40,12 @@ const insertEntreprises = async (indexName: string) => {
 
 if (require.main === module) {
   // use elastic alias feature to prevent downtimes
-  createIndex().then(async (indexName) =>
-    insertEntreprises(indexName)
+  console.log(`Creating index`);
+  createIndex().then(async (indexName) => {
+    console.log(`Starting indexation...`);
+    return insertEntreprises(indexName)
       .then(async () => {
+        console.log(`Indexation complete`);
         // ensure we have some data
         const docsCount = await getDocsCount(indexName);
         if (!docsCount) {
@@ -53,6 +57,6 @@ if (require.main === module) {
         }
       })
       .then(() => updateAlias(indexName))
-      .then(() => deleteOldIndices(indexName))
-  );
+      .then(() => deleteOldIndices(indexName));
+  });
 }


### PR DESCRIPTION
Use Es client builtin bulk method that handle streams, buffer, concurrency, retry...

For 2 946 778 documents :
 - local ES duration : ~4mins
 - using ES cloud : ~8mins
