### PR TITLE
feat(search) add some new fields

### DIFF
--- a/api/src/elastic/queries.ts
+++ b/api/src/elastic/queries.ts
@@ -48,6 +48,7 @@ export const mapHit = ({
     denominationUsuelle2UniteLegale,
     denominationUsuelle3UniteLegale,
     etatAdministratifEtablissement,
+    codeCommuneEtablissement,
     categorieEntreprise,
     etatAdministratifUniteLegale,
     caractereEmployeurUniteLegale,
@@ -130,6 +131,7 @@ export const mapHit = ({
     matching,
     firstMatchingEtablissement: {
       address: geo_adresse,
+      codeCommuneEtablissement,
       idccs,
       categorieEntreprise,
       siret,

--- a/api/src/elastic/queries.ts
+++ b/api/src/elastic/queries.ts
@@ -58,6 +58,7 @@ export const mapHit = ({
     geo_adresse,
     naming,
     idccs,
+    is_siege,
   },
   inner_hits,
   highlight,
@@ -102,10 +103,13 @@ export const mapHit = ({
   const allMatchingEtablissements = inner_hits.matchingEtablissements.hits.hits
     .filter((h: any) => h.fields)
     .map(
-      ({ fields: { "geo_adresse.keyword": address, siret, idccs } }: any) => ({
+      ({
+        fields: { "geo_adresse.keyword": address, siret, idccs, is_siege },
+      }: any) => ({
         address: address[0],
         siret: siret[0],
         idccs,
+        is_siege: is_siege[0],
       })
     );
 
@@ -136,6 +140,7 @@ export const mapHit = ({
       categorieEntreprise,
       siret,
       etatAdministratifEtablissement,
+      is_siege,
     },
     allMatchingEtablissements,
     simpleLabel,
@@ -150,7 +155,7 @@ const collapse = (withAllConventions: boolean) => ({
   field: "siren",
   inner_hits: {
     _source: false,
-    docvalue_fields: ["siret", "geo_adresse.keyword", "idccs"],
+    docvalue_fields: ["siret", "geo_adresse.keyword", "idccs", "is_siege"],
     name: "matchingEtablissements",
     size: withAllConventions ? 10000 : 1,
   },

--- a/api/src/elastic/queries.ts
+++ b/api/src/elastic/queries.ts
@@ -40,6 +40,7 @@ const formatLabel = (naming: string[]) => {
 export const mapHit = ({
   _source: {
     siren,
+    categorieJuridiqueUniteLegale,
     denominationUniteLegale,
     dateCreationUniteLegale,
     nomUniteLegale,
@@ -125,6 +126,7 @@ export const mapHit = ({
 
   return {
     activitePrincipale,
+    categorieJuridiqueUniteLegale,
     dateCreationUniteLegale,
     caractereEmployeurUniteLegale,
     conventions: Array.from(conventions.values()),

--- a/api/src/elastic/queries.ts
+++ b/api/src/elastic/queries.ts
@@ -41,6 +41,7 @@ export const mapHit = ({
   _source: {
     siren,
     denominationUniteLegale,
+    dateCreationUniteLegale,
     nomUniteLegale,
     nomUsageUniteLegale,
     denominationUsuelle1UniteLegale,
@@ -119,6 +120,7 @@ export const mapHit = ({
 
   return {
     activitePrincipale,
+    dateCreationUniteLegale,
     caractereEmployeurUniteLegale,
     conventions: Array.from(conventions.values()),
     etablissements: parseInt(etablissements),

--- a/api/src/lib/index.ts
+++ b/api/src/lib/index.ts
@@ -1,4 +1,4 @@
-import { ELASTICSEARCH_INDEX_NAME, elasticsearchClient } from "../elastic";
+import { elasticsearchClient, ELASTICSEARCH_INDEX_NAME } from "../elastic";
 import type { SearchArgs } from "../elastic/queries";
 import { entrepriseSearchBody, mapHit } from "../elastic/queries";
 

--- a/export.sql
+++ b/export.sql
@@ -37,6 +37,7 @@ SELECT
     geo_siret.indiceRepetitionEtablissement,
     geo_siret.typeVoieEtablissement,
     geo_siret.libelleVoieEtablissement,
+    stock.nicSiegeUniteLegale == geo_siret.nic as is_siege,
     weez.IDCC as idcc,
     (select count(*) FROM geo_siret where siren=stock.siren) etablissements
     from stock, geo_siret

--- a/export.sql
+++ b/export.sql
@@ -20,6 +20,7 @@ SELECT
     stock.categorieEntreprise,
     stock.etatAdministratifUniteLegale,
     stock.caractereEmployeurUniteLegale,
+    stock.dateCreationUniteLegale,
     geo_siret.siret,
     geo_siret.codePostalEtablissement,
     geo_siret.libelleCommuneEtablissement,

--- a/export.sql
+++ b/export.sql
@@ -24,6 +24,7 @@ SELECT
     geo_siret.siret,
     geo_siret.codePostalEtablissement,
     geo_siret.libelleCommuneEtablissement,
+    geo_siret.codeCommuneEtablissement,
     geo_siret.etatAdministratifEtablissement,
     geo_siret.enseigne1Etablissement,
     geo_siret.enseigne2Etablissement,

--- a/index/src/enterprise.ts
+++ b/index/src/enterprise.ts
@@ -13,6 +13,8 @@ export type Enterprise = {
   nomUsageUniteLegale: string;
   sigleUniteLegale: string;
 
+  dateCreationUniteLegale: string;
+
   denominationUniteLegale: string;
   denominationUsuelle1UniteLegale: string;
   denominationUsuelle2UniteLegale: string;
@@ -61,6 +63,8 @@ export const mappings = {
 
     caractereEmployeurUniteLegale: { type: "keyword" },
     categorieEntreprise: { type: "keyword" },
+
+    dateCreationUniteLegale: { type: "date" },
 
     categorieJuridiqueUniteLegale: { type: "keyword" },
     codePostalEtablissement: { type: "keyword" },

--- a/index/src/enterprise.ts
+++ b/index/src/enterprise.ts
@@ -35,6 +35,7 @@ export type Enterprise = {
   siret: string;
   codePostalEtablissement: string;
   libelleCommuneEtablissement: string;
+  codeCommuneEtablissement: string;
 
   // MOIS: '2020-07',
   // DATE_MAJ: '2020/08/28'
@@ -112,6 +113,10 @@ export const mappings = {
           type: "keyword",
         },
       },
+    },
+
+    codeCommuneEtablissement: {
+      type: "keyword",
     },
 
     naming: {

--- a/index/src/enterprise.ts
+++ b/index/src/enterprise.ts
@@ -1,5 +1,4 @@
 import agreements from "@socialgouv/kali-data/data/index.json";
-
 import { codesNaf } from "./naf";
 
 const ccMap = new Map(agreements.map((agg) => [agg.num, agg]));
@@ -41,6 +40,8 @@ export type Enterprise = {
   // DATE_MAJ: '2020/08/28'
 
   idccs: string[];
+
+  is_siege: string;
 
   geo_adresse: string;
 
@@ -86,6 +87,8 @@ export const mappings = {
 
     etatAdministratifEtablissement: { type: "keyword" },
     etatAdministratifUniteLegale: { type: "keyword" },
+
+    is_siege: { type: "boolean" },
 
     geo_adresse: {
       analyzer: "french_indexing",
@@ -240,5 +243,6 @@ export const mapEnterprise = (enterprise: Enterprise) => {
     ...Object.fromEntries(
       Object.entries(enterprise).filter(([k, v]) => k && v)
     ),
+    is_siege: enterprise.is_siege === "1",
   };
 };


### PR DESCRIPTION
Ceci est une simple reprise de la PR #125 de @bobylito, avec une petite modification pour un meilleur typage.

Pour rappel cette PR ajoute les nouveaux champs suivants, dont nous avons besoin sur mon-entreprise.

```
    codeCommuneEtablissement : id of the city / town
    is_siege : is the etablissement the main one for the company
    dateCreationUniteLegale : when the company was created
    categorieJuridiqueUniteLegale : the type of company
```

C'est un peu critique, nous souhaiterions passer dès que possible sur votre API, étant donné que celle de data.gouv.fr renvoie une 404 depuis le début de cette semaine.