### PR TITLE
fix: cleanup urls

### DIFF
--- a/.k8s/__tests__/__snapshots__/dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/dev.ts.snap
@@ -207,7 +207,7 @@ metadata:
   namespace: recherche-entreprises-mybranch
 spec:
   rules:
-    - host: api-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
+    - host: api-legacy-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -219,7 +219,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - api-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
+        - api-legacy-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
 apiVersion: apps/v1
@@ -361,7 +361,7 @@ metadata:
   namespace: recherche-entreprises-mybranch
 spec:
   rules:
-    - host: search-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
+    - host: api-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -373,7 +373,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - search-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
+        - api-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
 apiVersion: apps/v1
@@ -459,7 +459,7 @@ spec:
           env:
             - name: REACT_APP_API_URL
               value: >-
-                https://search-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr/api/v1
+                https://api-recherche-entreprises-mybranch.dev2.fabrique.social.gouv.fr/api/v1
 ---
 apiVersion: v1
 kind: Service

--- a/.k8s/__tests__/__snapshots__/indexing-dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/indexing-dev.ts.snap
@@ -364,6 +364,7 @@ data:
         geo_siret.typeVoieEtablissement,
         geo_siret.libelleVoieEtablissement,
         geo_siret.etablissementSiege,
+        geo_siret.codePaysEtrangerEtablissement,
         weez.IDCC as idcc,
         (select count(*) FROM geo_siret where siren=stock.siren) etablissements
         from stock, geo_siret

--- a/.k8s/__tests__/__snapshots__/indexing-preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/indexing-preprod.ts.snap
@@ -362,6 +362,7 @@ data:
         geo_siret.typeVoieEtablissement,
         geo_siret.libelleVoieEtablissement,
         geo_siret.etablissementSiege,
+        geo_siret.codePaysEtrangerEtablissement,
         weez.IDCC as idcc,
         (select count(*) FROM geo_siret where siren=stock.siren) etablissements
         from stock, geo_siret

--- a/.k8s/__tests__/__snapshots__/indexing-prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/indexing-prod.ts.snap
@@ -360,6 +360,7 @@ data:
         geo_siret.typeVoieEtablissement,
         geo_siret.libelleVoieEtablissement,
         geo_siret.etablissementSiege,
+        geo_siret.codePaysEtrangerEtablissement,
         weez.IDCC as idcc,
         (select count(*) FROM geo_siret where siren=stock.siren) etablissements
         from stock, geo_siret

--- a/.k8s/__tests__/__snapshots__/preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/preprod.ts.snap
@@ -206,7 +206,7 @@ metadata:
   namespace: recherche-entreprises-preprod
 spec:
   rules:
-    - host: api-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
+    - host: api-legacy-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -218,7 +218,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - api-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
+        - api-legacy-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
 apiVersion: apps/v1
@@ -360,7 +360,7 @@ metadata:
   namespace: recherche-entreprises-preprod
 spec:
   rules:
-    - host: search-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
+    - host: api-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -372,7 +372,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - search-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
+        - api-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
 apiVersion: apps/v1
@@ -458,7 +458,7 @@ spec:
           env:
             - name: REACT_APP_API_URL
               value: >-
-                https://search-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr/api/v1
+                https://api-recherche-entreprises-preprod.dev2.fabrique.social.gouv.fr/api/v1
 ---
 apiVersion: v1
 kind: Service

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -177,7 +177,7 @@ metadata:
   namespace: recherche-entreprises
 spec:
   rules:
-    - host: api-recherche-entreprises.fabrique.social.gouv.fr
+    - host: api-legacy-recherche-entreprises.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -189,7 +189,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - api-recherche-entreprises.fabrique.social.gouv.fr
+        - api-legacy-recherche-entreprises.fabrique.social.gouv.fr
       secretName: recherche-entreprises-api-crt
 ---
 apiVersion: apps/v1
@@ -328,7 +328,7 @@ metadata:
   namespace: recherche-entreprises
 spec:
   rules:
-    - host: search-recherche-entreprises.fabrique.social.gouv.fr
+    - host: api.recherche-entreprises.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -340,7 +340,7 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - search-recherche-entreprises.fabrique.social.gouv.fr
+        - api.recherche-entreprises.fabrique.social.gouv.fr
       secretName: recherche-entreprises-search-crt
 ---
 apiVersion: apps/v1
@@ -422,8 +422,7 @@ spec:
             periodSeconds: 5
           env:
             - name: REACT_APP_API_URL
-              value: >-
-                https://search-recherche-entreprises.fabrique.social.gouv.fr/api/v1
+              value: https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1
 ---
 apiVersion: v1
 kind: Service
@@ -512,5 +511,27 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/permanent-redirect: https://api.recherche-entreprises.fabrique.social.gouv.fr$request_uri
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: 'true'
+  labels:
+    app.kubernetes.io/component: redirect
+    app.kubernetes.io/name: www
+  name: www-redirect
+spec:
+  rules:
+    - host: search-recherche-entreprises.fabrique.social.gouv.fr
+    - host: api-recherche-entreprises.fabrique.social.gouv.fr
+  tls:
+    - hosts:
+        - search-recherche-entreprises.fabrique.social.gouv.fr
+        - api-recherche-entreprises.fabrique.social.gouv.fr
+      secretName: www-redirect
 "
 `;

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -523,7 +523,7 @@ metadata:
   labels:
     app.kubernetes.io/component: redirect
     app.kubernetes.io/name: www
-  name: www-redirect
+  name: recherche-entreprises-redirect
 spec:
   rules:
     - host: search-recherche-entreprises.fabrique.social.gouv.fr
@@ -532,6 +532,6 @@ spec:
     - hosts:
         - search-recherche-entreprises.fabrique.social.gouv.fr
         - api-recherche-entreprises.fabrique.social.gouv.fr
-      secretName: www-redirect
+      secretName: recherche-entreprises-redirect
 "
 `;

--- a/.k8s/components/api-legacy.ts
+++ b/.k8s/components/api-legacy.ts
@@ -1,14 +1,11 @@
 import env from "@kosko/env";
 import { create } from "@socialgouv/kosko-charts/components/app";
-import { addEnv, getDeployment } from "@socialgouv/kosko-charts/utils";
-import { getGithubRegistryImagePath } from "@socialgouv/kosko-charts/utils/getGithubRegistryImagePath";
-import { EnvVar } from "kubernetes-models/v1";
 
 const getManifests = async () => {
   const manifests = await create("recherche-entreprises-api", {
     config: {
       containerPort: 3000,
-      subDomainPrefix: "api-",
+      subDomainPrefix: "api-legacy-",
     },
     deployment: {
       image:

--- a/.k8s/components/api.ts
+++ b/.k8s/components/api.ts
@@ -8,7 +8,7 @@ const getManifests = async () => {
   const manifests = await create("recherche-entreprises-search", {
     config: {
       containerPort: 3000,
-      subDomainPrefix: "search-",
+      subDomainPrefix: env.env === "prod" ? "api." : "api-",
     },
     deployment: {
       image: getGithubRegistryImagePath({

--- a/.k8s/components/yaml.ts
+++ b/.k8s/components/yaml.ts
@@ -1,0 +1,9 @@
+import env from "@kosko/env";
+import { importYamlFolder } from "@socialgouv/kosko-charts/components/yaml";
+import path from "path";
+
+const manifests = importYamlFolder(
+  path.join(__dirname, "..", `environments/${env.env}/yaml`)
+);
+
+export default manifests;

--- a/.k8s/environments/prod/yaml/redirect.yaml
+++ b/.k8s/environments/prod/yaml/redirect.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/permanent-redirect: https://api.recherche-entreprises.fabrique.social.gouv.fr$request_uri
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app.kubernetes.io/component: redirect
+    app.kubernetes.io/name: www
+  name: www-redirect
+  namespace: incubateur
+spec:
+  rules:
+    - host: search-recherche-entreprises.fabrique.social.gouv.fr
+    - host: api-recherche-entreprises.fabrique.social.gouv.fr
+  tls:
+    - hosts:
+        - search-recherche-entreprises.fabrique.social.gouv.fr
+        - api-recherche-entreprises.fabrique.social.gouv.fr
+      secretName: www-redirect

--- a/.k8s/environments/prod/yaml/redirect.yaml
+++ b/.k8s/environments/prod/yaml/redirect.yaml
@@ -9,8 +9,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redirect
     app.kubernetes.io/name: www
-  name: www-redirect
-  namespace: incubateur
+  name: recherche-entreprises-redirect
+  namespace: recherche-entreprises
 spec:
   rules:
     - host: search-recherche-entreprises.fabrique.social.gouv.fr
@@ -19,4 +19,4 @@ spec:
     - hosts:
         - search-recherche-entreprises.fabrique.social.gouv.fr
         - api-recherche-entreprises.fabrique.social.gouv.fr
-      secretName: www-redirect
+      secretName: recherche-entreprises-redirect

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Le dossier [`api`](./api) présente un exemple d'implémentation d'API NodeJS qu
 
 Un frontend de démo est disponible ici : https://recherche-entreprises.fabrique.social.gouv.fr
 
-Et vous pouvez utiliser librement l'API disponible sur https://api-recherche-entreprises.fabrique.social.gouv.fr cf [documentation API](./api/README.md)
+Et vous pouvez utiliser librement l'API disponible sur https://api.recherche-entreprises.fabrique.social.gouv.fr cf [documentation API](./api/README.md)
 
-Exemple : [/api/v1/search?q=plume&a=paris](https://api-recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?q=plume&a=paris)
+Exemple : [/api/v1/search?q=plume&a=paris](https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?q=plume&a=paris)
 
 ## Étapes :
 
@@ -45,7 +45,6 @@ Le script `sqlite.sh` permet de permet de télécharger les CSV puis aggréger l
 Le fichier `./data/assembly.csv` fait +6Go avec plus de 30 millions de lignes.
 
 Cette opération dure environ 45 minutes.
-
 
 ### Indexation dans Elastic Search
 


### PR DESCRIPTION
 - use `api.recherche-entreprises` as default API endpoint
 - add redirects for old urls